### PR TITLE
Copy platformsh-cli from another Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,8 @@ COPY bin/ /usr/local/bin
 
 COPY --from=platformcli /usr/local/bin/platform /usr/local/bin/platform
 
+# Let's make sure we can actually run the command and let's out the
+# installed version in the build log.
+RUN platform --version
+
 ENTRYPOINT [ "entrypoint" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM pjcdawkins/platformsh-cli@sha256:83c4cf2da7c8e0cd411e1ba8740ef198c69d1b4255e6196ae85620dc23504ef6 AS platformcli
+
 FROM php:7-cli-alpine3.12
 
 RUN apk add --no-cache "openssh>=8.3"
@@ -6,6 +8,6 @@ RUN printf "    StrictHostKeyChecking  no\n    UserKnownHostsFile /dev/null\n" >
 
 COPY bin/ /usr/local/bin
 
-RUN curl --fail -sSL https://github.com/platformsh/platformsh-cli/releases/latest/download/platform.phar -o /usr/local/bin/platform && chmod +x /usr/local/bin/platform
+COPY --from=platformcli /usr/local/bin/platform /usr/local/bin/platform
 
 ENTRYPOINT [ "entrypoint" ]


### PR DESCRIPTION
No need to curl it ourselves.

This will trigger a pull request from @dependabot whenever there is a new version of platformsh-cli (that isn't be the case with curl).

There is no tagged releases of https://hub.docker.com/r/pjcdawkins/platformsh-cli, though. Only `latest`.

But apparently `FROM` lines can references the digest of the image _and_ @dependabot should be able to update based on digests as well (TIL).

Although https://hub.docker.com/r/pjcdawkins/platformsh-cli doesn't appear to an official platformsh-cli image, @pjcdawkins is an employee of Platform.sh and the image appears to get updates fast and automated.
