### PR TITLE
Use a checksum version of an unspeciefied 8-cli-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # hadolint ignore=DL3007
 FROM pjcdawkins/platformsh-cli:latest@sha256:21236e8bce328a76491ab323a19171c38bdb9ba6b60afbefe6cd034e0eae834c AS platformcli
 
-FROM php:8-cli-alpine3.13
+FROM php:8-cli-alpine@sha256:28078e2f56e3d76e1e5e8803c8abbdbbc9aa0a4aac2736178af99b46b744f758
 
 RUN apk add --no-cache "openssh>=8.3" \
  && printf "    StrictHostKeyChecking  no\n    UserKnownHostsFile /dev/null\n" >> /etc/ssh/ssh_config


### PR DESCRIPTION
This will let Dependabot create a PR every time a new version of a
php:8-cli-alpine image is released.
