### PR TITLE
Use main branch of actionshub/markdownlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run markdownlint
-      uses: actionshub/markdownlint@2.0.2
+      uses: actionshub/markdownlint@main
 
   shellcheck:
     name: shellcheck


### PR DESCRIPTION
actionshub/markdownlint has migrated to the main branch as default,
the master branch will be removed
